### PR TITLE
Substituted DeDRM_tools with its maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 ## Paywall and DRM breakers
 
 - [Bypass Paywalls Chrome](https://github.com/iamadamdev/bypass-paywalls-chrome) - Paywall breaker for major newspapers around the world
-- [DeDRM Tools](https://github.com/apprenticeharper/DeDRM_tools/) - DRM removal for eBooks
+- [DeDRM Tools](https://github.com/noDRM/DeDRM_tools) - DRM removal for eBooks
 
 ## Open Access tools
 


### PR DESCRIPTION
`DeDRM_tools` by @apprenticeharper is no longer maintained, I have replaced it with its updated fork made by @noDRM.